### PR TITLE
Add --export-checkpoint Flag to segment.py for Exporting Segmented Checkpoints

### DIFF
--- a/segment.py
+++ b/segment.py
@@ -405,7 +405,7 @@ def main(
 
     if export_checkpoint:
         save_to_ckpt(
-            f"{results_dir}/deleted.pt",
+            f"{results_dir}/extracted.pt",
             extracted
         )
         save_to_ckpt(

--- a/segment.py
+++ b/segment.py
@@ -345,6 +345,21 @@ def render_to_gif(
     if feedback:
         cv2.destroyAllWindows()
 
+def save_to_ckpt(
+    output_path: str,
+    splats,
+):
+    # Save Torch Checkpoint
+    checkpoint_data = {"splats": {
+        "means": splats["means"],
+        "quats": splats["rotation"],
+        "scales": splats["scaling"],
+        "opacities": splats["opacity"],
+        "sh0": splats["features_dc"],
+        "shN": splats["features_rest"],
+    }}
+    torch.save(checkpoint_data, output_path)
+
 
 def main(
     data_dir: str = "./data/garden",  # colmap path
@@ -357,6 +372,7 @@ def main(
     neg_prompt: str = "Vase;Other",
     data_factor: int = 4,
     show_visual_feedback: bool = True,
+    export_checkpoint: bool = False,
 ):
 
     if not torch.cuda.is_available():
@@ -381,7 +397,21 @@ def main(
         show_visual_feedback,
         use_checkerboard_background=True,
     )
-    render_to_gif(f"{results_dir}/deleted.gif", deleted, show_visual_feedback)
+    render_to_gif(
+        f"{results_dir}/deleted.gif",
+        deleted,
+        show_visual_feedback
+    )
+
+    if export_checkpoint:
+        save_to_ckpt(
+            f"{results_dir}/deleted.pt",
+            extracted
+        )
+        save_to_ckpt(
+            f"{results_dir}/deleted.pt",
+            deleted
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description  
This PR introduces a new feature to the `segment.py` script by adding the `--export-checkpoint` flag. This flag allows the Segmentation process to export splats into segmented checkpoint files for further processing and viewing

## Changes Made  
1. Added the `--export-checkpoint` flag to the `segment.py` script.  
2. When enabled, the segmentation process exports two checkpoint files:  
   - `extracted.pt`  
   - `delete.pt`  

## Affected Code  
- `segment.py`: Added support for the `--export-checkpoint` flag to enable checkpoint export functionality.  

## Testing  
Tested the function on a system with the following configuration:
- **CPU**: AMD Ryzen 7 3800X
- **RAM**: 32 GB
- **GPU**: NVIDIA RTX 4060 Ti (16 GB VRAM)

- [X] Tested the `--export-checkpoint` flag to verify that it successfully creates `extracted.pt` and `delete.pt` checkpoint files. 
- [X] Tested the exported checkpoint files with the [gsplat simple_viewer.py](https://github.com/nerfstudio-project/gsplat/blob/main/examples/simple_viewer.py).

---

Please review the changes and let me know if any further modifications are needed!  