### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ python backproject.py --help
 
 **Segmentation**
 
-Once backprojection is completed, run the following to see the segmenation results.
+Once backprojection is completed, run the following to see the segmentation results.
 
 ```bash
 python segment.py --help


### PR DESCRIPTION
## Summary
- fix a typo in the segmentation instructions

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_6841c2a9c718832fb3bff67003c632fe