### PR TITLE
Fix minor typos

### DIFF
--- a/affordance_transfer/README.md
+++ b/affordance_transfer/README.md
@@ -1,6 +1,6 @@
 # README
 
-The code need to be refactored and not documented.
+The code needs to be refactored and is not documented.
 
 To run,
 

--- a/f3dgs/datasets/download_dataset.py
+++ b/f3dgs/datasets/download_dataset.py
@@ -41,7 +41,7 @@ class DownloadData:
         ]
         try:
             subprocess.run(download_command, check=True)
-            print("File file downloaded succesfully.")
+            print("File downloaded successfully.")
         except subprocess.CalledProcessError as e:
             print(f"Error downloading file: {e}")
 

--- a/viewer_with_llm.py
+++ b/viewer_with_llm.py
@@ -62,7 +62,7 @@ def get_mask3d_lseg(splats, features, prompt, neg_prompt, threshold=None):
     # Preprocess the text prompt
     clip_text_encoder = net.clip_pretrained.encode_text
 
-    positve_prompts_length = len(prompt.split(";"))
+    positive_prompts_length = len(prompt.split(";"))
 
     prompts = prompt.split(";") + neg_prompt.split(";")
 
@@ -74,7 +74,7 @@ def get_mask3d_lseg(splats, features, prompt, neg_prompt, threshold=None):
 
     features = torch.nn.functional.normalize(features, dim=1)
     score = features @ text_feat_norm.float().T
-    mask_3d = score[:, :positve_prompts_length].max(dim=1)[0] > score[:, positve_prompts_length:].max(dim=1)[0]
+    mask_3d = score[:, :positive_prompts_length].max(dim=1)[0] > score[:, positive_prompts_length:].max(dim=1)[0]
     if threshold is not None:
         mask_3d = mask_3d & (score[:, 0] > threshold)
     mask_3d_inv = ~mask_3d


### PR DESCRIPTION
## Summary
- correct prompt length variable name in viewer_with_llm
- fix download status string
- clarify README grammar in affordance_transfer

## Testing
- `python -m py_compile viewer_with_llm.py f3dgs/datasets/download_dataset.py`

------
https://chatgpt.com/codex/tasks/task_e_6841c3efbc9c832f8c116e1ac87302f1