### PR TITLE
Enable multiple positive prompts in segmentation

### DIFF
--- a/segment_f3dgs.py
+++ b/segment_f3dgs.py
@@ -41,7 +41,9 @@ def get_mask3d_lseg(splats, features, prompt, neg_prompt, threshold=None):
     # Preprocess the text prompt
     clip_text_encoder = net.clip_pretrained.encode_text
 
-    prompts = [prompt] + neg_prompt.split(";")
+    pos_prompt_length = len(prompt.split(";"))
+
+    prompts = prompt.split(";") + neg_prompt.split(";")
 
     prompt = clip.tokenize(prompts)
     prompt = prompt.cuda()
@@ -51,7 +53,7 @@ def get_mask3d_lseg(splats, features, prompt, neg_prompt, threshold=None):
 
     features = torch.nn.functional.normalize(features, dim=1)
     score = features @ text_feat_norm.float().T
-    mask_3d = score[:, 0] > score[:, 1:].max(dim=1)[0]
+    mask_3d = score[:, :pos_prompt_length].max(dim=1)[0] > score[:, pos_prompt_length:].max(dim=1)[0]
     if threshold is not None:
         mask_3d = mask_3d & (score[:, 0] > threshold)
     mask_3d_inv = ~mask_3d
@@ -180,7 +182,9 @@ def render_mask_2d_to_gif_f3dgs(
     # Preprocess the text prompt
     clip_text_encoder = net.clip_pretrained.encode_text
 
-    prompts = [prompt] + neg_prompt.split(";")
+    pos_prompt_length = len(prompt.split(";"))
+
+    prompts = prompt.split(";") + neg_prompt.split(";")
 
     prompt = clip.tokenize(prompts)
     prompt = prompt.cuda()
@@ -219,7 +223,7 @@ def render_mask_2d_to_gif_f3dgs(
         feats_rendered = feats_rendered[0] @ conv
         feats_rendered = torch.nn.functional.normalize(feats_rendered, dim=-1)
         score = feats_rendered @ text_feat_norm.float().T
-        mask2d = score[..., 0] > score[..., 1:].max(dim=2)[0]
+        mask2d = score[..., :pos_prompt_length].max(dim=2)[0] > score[..., pos_prompt_length:].max(dim=2)[0]
         # print(mask2d.shape)
         mask2d = mask2d[..., None].detach().cpu().numpy()
         frame = np.clip(output[0].detach().cpu().numpy() * 255, 0, 255).astype(np.uint8)


### PR DESCRIPTION
## Summary
- allow multiple positive prompts separated by semicolons in `segment_compressed.py` and `segment_f3dgs.py`
- update mask computation in 2D and 3D segmentation accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a8f3509a0832f97abd4dbdfd1723f